### PR TITLE
Feature/set mockhttpfactory baseuri

### DIFF
--- a/tests/Utils/MockHttpClientFactory.cs
+++ b/tests/Utils/MockHttpClientFactory.cs
@@ -7,8 +7,17 @@ internal class MockHttpClientFactory : IHttpClientFactory
 {
     private static MockHttpMessageHandler _mockHttpMessageHandler;
 
+    private static string _baseUri;
+
     public static void Set(MockHttpMessageHandler httpClient)
         => _mockHttpMessageHandler = httpClient;
+
+    public static void SetBaseUri(string baseUri)
+    {
+        ArgumentNullException.ThrowIfNull(_baseUri);
+
+        _baseUri = baseUri;
+    }
 
     public HttpClient CreateClient(string name)
     {

--- a/tests/Utils/MockHttpClientFactory.cs
+++ b/tests/Utils/MockHttpClientFactory.cs
@@ -23,6 +23,11 @@ internal class MockHttpClientFactory : IHttpClientFactory
     {
         ArgumentNullException.ThrowIfNull(_mockHttpMessageHandler);
 
-        return _mockHttpMessageHandler.ToHttpClient();
+        if(string.IsNullOrEmpty(_baseUri))
+        {
+            return _mockHttpMessageHandler.ToHttpClient();
+        }
+
+        return new HttpClient(_mockHttpMessageHandler) { BaseAddress = new(_baseUri) };
     }
 }


### PR DESCRIPTION
## Features
- Added hability to set the base uri, on the HttpClient, during Integration tests;

## Why?
- Imagine, you have your base url, to call the external API, on a config file, the request uri, you would be passing to ``HttpClient.SendAsync()`` sometimes would be a partial, because the Base uri, would already be set, in a production environment;
- But, if we leave it like this, the integration test, would fail, because no base uri was set;